### PR TITLE
Change add_stylesheet to add_css_file

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -221,4 +221,4 @@ epub_exclude_files = ['search.html']
 
 # entry point for setup
 def setup(app):
-    app.add_stylesheet('css/fixes.css')
+    app.add_css_file('css/fixes.css')


### PR DESCRIPTION
`app.add_stylesheet` has been deprecated since Sphinx 1.8.0b1, and has been removed entirely from Sphinx 6.x.